### PR TITLE
Add two new sushi pools

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,9 +31,9 @@ const App: React.FC = () => {
           <Route exact path="/earn" component={Earn} />
           <Route exact path="/earn/supply/:tokenAddress" component={Supply} />
           <Route exact path="/earn/withdraw/:tokenAddress" component={Withdraw} />
-          <Route exact path="/farm/new/:name/:wrapper/:spell/:lp/:apy/:tokens/:type" component={NewFarm} />
-          <Route exact path="/positions/add/:positionId/:collId/:collateralSize/:name/:wrapper/:spell/:lp/:apy/:tokens/:type" component={Add} />
-          <Route exact path="/positions/remove/:positionId/:collId/:collateralSize/:name/:wrapper/:spell/:lp/:apy/:tokens/:type" component={Remove} />
+          <Route exact path="/farm/new/:name/:wrapper/:spell/:lp/:apy/:tokens/:type/:id" component={NewFarm} />
+          <Route exact path="/positions/add/:positionId/:collId/:collateralSize/:name/:wrapper/:spell/:lp/:apy/:tokens/:type/:id" component={Add} />
+          <Route exact path="/positions/remove/:positionId/:collId/:collateralSize/:name/:wrapper/:spell/:lp/:apy/:tokens/:type/:id" component={Remove} />
           <Route exact path="/farm" component={Farm}/>
           <Route exact path="/positions" component={Position}/>
           <ToastContainer />

--- a/src/components/FarmInfo.tsx
+++ b/src/components/FarmInfo.tsx
@@ -1,8 +1,8 @@
 import { PoolIcon } from "src/components/PoolIcon";
-import { poolProps } from "src/pages/Farm/newFarm/NewFarm";
+import { Farm } from "src/config";
 
 interface Props {
-  props: poolProps;
+  props: Farm;
 }
 
 export const FarmInfo: React.FC<Props> = (farm: Props) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@ import { getAddress } from "ethers/lib/utils";
 
 
 export const Bank = {
-  [ChainId.Mainnet]: getAddress("0x827cCeA3D460D458393EEAfE831698d83FE47BA7"),
+  [ChainId.Mainnet]: getAddress("0xD598a21bA32B1B2c70950d38E4651528E47e0471"),
   [ChainId.Alfajores]: getAddress("0x000531a6B61550cfADb637a625A00236fcDD1bDB"),
   [ChainId.Baklava]: getAddress("0x000531a6B61550cfADb637a625A00236fcDD1bDB"),
 };
@@ -83,11 +83,23 @@ export enum FarmType {
   Ubeswap = "Ubeswap"
 }
 
-export const FARMS = [
+export interface Farm {
+  name: string
+  spell: string
+  wrapper: string
+  lp: string
+  apy: string
+  tokens: Token[]
+  type: FarmType
+  id?: string
+  rewards: Token[]
+}
+
+export const FARMS : Farm[] = [
   {
-    name: "cUSD-cEUR",
-    wrapper: getAddress("0xE583FeC0B218bB89CbB24d76D2A6D901E082DAAA"),
-    spell: getAddress("0x4163A7dB783D3d6d761Bd9060EcDe42D1C2D8c74"),
+    name: "cUSD-cEUR v1",
+    wrapper: getAddress("0x88EFB15fBeb0A542e9B05443e2578817Bb773E16"),
+    spell: getAddress("0xCb5cF76c3D1A5a8A0D80312A76eF0b3C965b4Ad1"),
     lp: getAddress("0x0b655E7D966CB27998af94AA5719ab7BFe07D3b3"),
     apy: "51", 
     tokens: [
@@ -109,9 +121,100 @@ export const FARMS = [
       }),
     ],
     type: FarmType.SushiSwap,
+    id: '3',
     rewards: [
       new Token({
         address: getAddress("0xD15EC721C2A896512Ad29C671997DD68f9593226"),
+        name: "Sushi",
+        symbol: "SUSHI",
+        decimals: 18,
+        chainId: ChainId.Mainnet,
+        logoURI: "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_SUSHI.png",
+      }),
+      new Token({
+        address: getAddress("0x471EcE3750Da237f93B8E339c536989b8978a438"),
+        name: "Celo",
+        symbol: "CELO",
+        decimals: 18,
+        chainId: ChainId.Mainnet,
+        logoURI: "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_CELO.png",
+        }),
+    ],
+  },
+  {
+    name: "cUSD-cEUR v2",
+    wrapper: getAddress("0xDCB1d0E68Bdec9756d3666C0C96dABFEa6d6B6Dc"),
+    spell: getAddress("0x4378E8E7836E186a844c63267B32dF26e7ef24Ac"),
+    lp: getAddress("0x0b655E7D966CB27998af94AA5719ab7BFe07D3b3"),
+    apy: "51", 
+    tokens: [
+      new Token({
+        address: getAddress("0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73"),
+        name: "Celo Euro",
+        symbol: "cEUR",
+        decimals: 18,
+        chainId: ChainId.Mainnet,
+        logoURI: "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cEUR.png",
+      }),
+      new Token({
+        address: getAddress("0x765DE816845861e75A25fCA122bb6898B8B1282a"),
+        name: "Celo Dollar",
+        symbol: "cUSD",
+        decimals: 18,
+        chainId: ChainId.Mainnet,
+        logoURI: "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cUSD.png",
+      }),
+    ],
+    type: FarmType.SushiSwap,
+    id: '3',
+    rewards: [
+      new Token({
+        address: getAddress("0x29dFce9c22003A4999930382Fd00f9Fd6133Acd1"),
+        name: "Sushi",
+        symbol: "SUSHI",
+        decimals: 18,
+        chainId: ChainId.Mainnet,
+        logoURI: "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_SUSHI.png",
+      }),
+      new Token({
+        address: getAddress("0x471EcE3750Da237f93B8E339c536989b8978a438"),
+        name: "Celo",
+        symbol: "CELO",
+        decimals: 18,
+        chainId: ChainId.Mainnet,
+        logoURI: "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_CELO.png",
+        }),
+    ],
+  },
+  {
+    name: "CELO-MOBI",
+    wrapper: getAddress("0xDCB1d0E68Bdec9756d3666C0C96dABFEa6d6B6Dc"),
+    spell: getAddress("0x4378E8E7836E186a844c63267B32dF26e7ef24Ac"),
+    lp: getAddress("0x8ecded81a2abf3b7e724978060739edbeb01b24f"),
+    apy: "51", 
+    tokens: [
+      new Token({
+        address: getAddress("0x471ece3750da237f93b8e339c536989b8978a438"),
+        name: "Celo",
+        symbol: "CELO",
+        decimals: 18,
+        chainId: ChainId.Mainnet,
+        logoURI: "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_CELO.png",
+      }),
+      new Token({
+        address: getAddress("0x73a210637f6F6B7005512677Ba6B3C96bb4AA44B"),
+        name: "Mobius",
+        symbol: "MOBI",
+        decimals: 18,
+        chainId: ChainId.Mainnet,
+        logoURI: "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_MOBI.png"
+      }),
+    ],
+    type: FarmType.SushiSwap,
+    id: '8',
+    rewards: [
+      new Token({
+        address: getAddress("0x29dFce9c22003A4999930382Fd00f9Fd6133Acd1"),
         name: "Sushi",
         symbol: "SUSHI",
         decimals: 18,
@@ -230,16 +333,16 @@ export const DECIMAL_PRECISION = 2; // Number of decimals to show
 
 //collateral type to safebox
 export const safeBoxMap = new Map<string, string>([
-  [getAddress("0x765DE816845861e75A25fCA122bb6898B8B1282a"), getAddress("0xb104422F2Fbc050055671265b95E08aD6057B0B3")], // cusd
-  [getAddress("0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73"), getAddress("0x998BA352aD84CC0CD7E71B1Cc11Fd192D624254C")], // ceur
-  [getAddress("0x471ece3750da237f93b8e339c536989b8978a438"), getAddress("0x7a6d627b0464dd33C988AE3a99aa6372191E7EB2")], // celo
-  [getAddress("0x00Be915B9dCf56a3CBE739D9B9c202ca692409EC"), getAddress("0x37a022Bd03A8b0F66ea68996410E0F70EC395C5e")], // ube
-  [getAddress("0x73a210637f6F6B7005512677Ba6B3C96bb4AA44B"), getAddress("0xEfbD2788A0dea9EB959a61CE0098Be6499fB0d78")], // mobi
+  [getAddress("0x765DE816845861e75A25fCA122bb6898B8B1282a"), getAddress("0x85271d63FaBBEbb6194c2A1FFC2F55047E4cb839")], // cusd
+  [getAddress("0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73"), getAddress("0xfc6eE763CefaF7FFc25ceE9251d50FB8890992F9")], // ceur
+  [getAddress("0x471ece3750da237f93b8e339c536989b8978a438"), getAddress("0x24B162B4Bb738b09757A099650c588daC28E9e2d")], // celo
+  [getAddress("0x00Be915B9dCf56a3CBE739D9B9c202ca692409EC"), getAddress("0x97931360B98DD11fA0Bc8AD4FB8Ce44D856CA927")], // ube
+  [getAddress("0x73a210637f6F6B7005512677Ba6B3C96bb4AA44B"), getAddress("0x39d90818304992270bd131471EF3ACd20a4aaE2A")], // mobi
 ]);
 
 export const DEFAULT_GAS_PRICE = toWei("0.5", "gwei");
 
-export const sushiLPadd = getAddress("0x02F726B5E819eCF33aA93be5274c94a22Df3619f")
+export const sushiLPadd = getAddress("0x7072a1c2c9A0cb20ae0B3C0C9023a42a49542e8B")
 
 export const priceScale = toBN(2).pow(toBN(112))
 export const scale = toBN(10).pow(toBN(18))

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@ import { getAddress } from "ethers/lib/utils";
 
 
 export const Bank = {
-  [ChainId.Mainnet]: getAddress("0xD598a21bA32B1B2c70950d38E4651528E47e0471"),
+  [ChainId.Mainnet]: getAddress("0x827cCeA3D460D458393EEAfE831698d83FE47BA7"),
   [ChainId.Alfajores]: getAddress("0x000531a6B61550cfADb637a625A00236fcDD1bDB"),
   [ChainId.Baklava]: getAddress("0x000531a6B61550cfADb637a625A00236fcDD1bDB"),
 };
@@ -98,8 +98,8 @@ export interface Farm {
 export const FARMS : Farm[] = [
   {
     name: "cUSD-cEUR v1",
-    wrapper: getAddress("0x88EFB15fBeb0A542e9B05443e2578817Bb773E16"),
-    spell: getAddress("0xCb5cF76c3D1A5a8A0D80312A76eF0b3C965b4Ad1"),
+    wrapper: getAddress("0xE583FeC0B218bB89CbB24d76D2A6D901E082DAAA"),
+    spell: getAddress("0x4163A7dB783D3d6d761Bd9060EcDe42D1C2D8c74"),
     lp: getAddress("0x0b655E7D966CB27998af94AA5719ab7BFe07D3b3"),
     apy: "51", 
     tokens: [
@@ -143,8 +143,8 @@ export const FARMS : Farm[] = [
   },
   {
     name: "cUSD-cEUR v2",
-    wrapper: getAddress("0xDCB1d0E68Bdec9756d3666C0C96dABFEa6d6B6Dc"),
-    spell: getAddress("0x4378E8E7836E186a844c63267B32dF26e7ef24Ac"),
+    wrapper: getAddress("0x1C4da0695aE25847260628d7eA92c5d336Fe1998"),
+    spell: getAddress("0x70CFe574715213782B3BcCfFcbb8d4a298388de7"),
     lp: getAddress("0x0b655E7D966CB27998af94AA5719ab7BFe07D3b3"),
     apy: "51", 
     tokens: [
@@ -188,8 +188,8 @@ export const FARMS : Farm[] = [
   },
   {
     name: "CELO-MOBI",
-    wrapper: getAddress("0xDCB1d0E68Bdec9756d3666C0C96dABFEa6d6B6Dc"),
-    spell: getAddress("0x4378E8E7836E186a844c63267B32dF26e7ef24Ac"),
+    wrapper: getAddress("0x1C4da0695aE25847260628d7eA92c5d336Fe1998"),
+    spell: getAddress("0x70CFe574715213782B3BcCfFcbb8d4a298388de7"),
     lp: getAddress("0x8ecded81a2abf3b7e724978060739edbeb01b24f"),
     apy: "51", 
     tokens: [
@@ -333,11 +333,11 @@ export const DECIMAL_PRECISION = 2; // Number of decimals to show
 
 //collateral type to safebox
 export const safeBoxMap = new Map<string, string>([
-  [getAddress("0x765DE816845861e75A25fCA122bb6898B8B1282a"), getAddress("0x85271d63FaBBEbb6194c2A1FFC2F55047E4cb839")], // cusd
-  [getAddress("0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73"), getAddress("0xfc6eE763CefaF7FFc25ceE9251d50FB8890992F9")], // ceur
-  [getAddress("0x471ece3750da237f93b8e339c536989b8978a438"), getAddress("0x24B162B4Bb738b09757A099650c588daC28E9e2d")], // celo
-  [getAddress("0x00Be915B9dCf56a3CBE739D9B9c202ca692409EC"), getAddress("0x97931360B98DD11fA0Bc8AD4FB8Ce44D856CA927")], // ube
-  [getAddress("0x73a210637f6F6B7005512677Ba6B3C96bb4AA44B"), getAddress("0x39d90818304992270bd131471EF3ACd20a4aaE2A")], // mobi
+  [getAddress("0x765DE816845861e75A25fCA122bb6898B8B1282a"), getAddress("0xb104422F2Fbc050055671265b95E08aD6057B0B3")], // cusd
+  [getAddress("0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73"), getAddress("0x998BA352aD84CC0CD7E71B1Cc11Fd192D624254C")], // ceur
+  [getAddress("0x471ece3750da237f93b8e339c536989b8978a438"), getAddress("0x7a6d627b0464dd33C988AE3a99aa6372191E7EB2")], // celo
+  [getAddress("0x00Be915B9dCf56a3CBE739D9B9c202ca692409EC"), getAddress("0x37a022Bd03A8b0F66ea68996410E0F70EC395C5e")], // ube
+  [getAddress("0x73a210637f6F6B7005512677Ba6B3C96bb4AA44B"), getAddress("0xEfbD2788A0dea9EB959a61CE0098Be6499fB0d78")], // mobi
 ]);
 
 export const DEFAULT_GAS_PRICE = toWei("0.5", "gwei");

--- a/src/pages/Farm/Farm.tsx
+++ b/src/pages/Farm/Farm.tsx
@@ -28,6 +28,7 @@ export const Farm = () => {
                   lp={farm.lp}
                   rewards={farm.rewards}
                   type={farm.type}
+                  id={farm.id}
                 />
               ))}
             </section>

--- a/src/pages/Farm/FarmEntry.tsx
+++ b/src/pages/Farm/FarmEntry.tsx
@@ -7,7 +7,7 @@ import PROXYORACLE_ABI from "src/abis/dahlia_contracts/ProxyOracle.json";
 import { HomoraBank } from "src/generated/HomoraBank";
 import { ProxyOracle } from "src/generated/ProxyOracle";
 import { CErc20Immutable } from "src/generated/CErc20Immutable";
-import { Bank } from "src/config";
+import { Bank, Farm } from "src/config";
 import React from "react";
 import { useAsyncState } from "src/hooks/useAsyncState";
 import { getAddress } from "ethers/lib/utils";
@@ -15,19 +15,18 @@ import { humanFriendlyWei } from "src/utils/eth";
 import { FarmInfo } from "src/components/FarmInfo";
 import { RewardsTokenInfo } from "src/components/RewardsTokenInfo";
 import { TokenBorrowInfo } from "src/components/TokenBorrowInfo";
-import { poolProps } from "src/pages/Farm/newFarm/NewFarm";
 import { humanFriendlyNumber } from "src/utils/number";
 import { useAPR } from "src/hooks/useAPR";
 
-export const FarmEntry: React.FC<poolProps> = (props: poolProps) => {
+export const FarmEntry: React.FC<Farm> = (props: Farm) => {
   const { kit, network } = useContractKit();
   const history = useHistory();
-  const [apr, refetchapr] = useAPR(
+  const [apr] = useAPR(
     props.lp,
     props.wrapper,
     props.type,
+    props.id,
   );
-  console.log('apr', apr)
 
   const bank = React.useMemo(
     () =>
@@ -130,7 +129,9 @@ export const FarmEntry: React.FC<poolProps> = (props: poolProps) => {
     "/" +
     props.tokens.map((tok) => tok.address) +
     "/" +
-    props.type;
+    props.type +
+    "/" +
+    props.id ?? '';
 
   return (
     <div className="w-full md:w-1/3">

--- a/src/pages/Farm/newFarm/NewFarm.tsx
+++ b/src/pages/Farm/newFarm/NewFarm.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { atom, useSetRecoilState, useRecoilState } from 'recoil';
-import { getToken, Token } from "src/utils/token";
+import { getToken } from "src/utils/token";
 import { useParams } from "react-router-dom";
 import { Supply } from "src/pages/Farm/newFarm/supply";
 import { Borrow } from "src/pages/Farm/newFarm/borrow";
 import { Confirm } from "src/pages/Farm/newFarm/confirm";
-import { FarmType } from "src/config"
+import { Farm, FarmType } from "src/config"
 import { getFarm } from "src/utils/farm";
 
 export enum farmPage {
@@ -19,18 +19,7 @@ export const farmPageState = atom({
   default: farmPage.Supply
 })
 
-export interface poolProps {
-    name: string;
-    wrapper: string;
-    spell: string;
-    lp: string;
-    apy: string;
-    tokens: Token[];
-    rewards: Token[];
-    type: FarmType;
-}
-
-const emptyPoolState : poolProps = {
+const emptyPoolState : Farm = {
     name: "",
     wrapper: "",
     spell: "",
@@ -47,9 +36,9 @@ export const poolState = atom({
 })
 
 export const NewFarm: React.FC = () => {
-  const { name, wrapper, spell, lp, apy, tokens, type } = useParams<{ name: string, wrapper: string, spell: string, lp: string, apy: string, tokens: string, type: string }>();
+  const { name, wrapper, spell, lp, apy, tokens, type, id } = useParams<{ name: string, wrapper: string, spell: string, lp: string, apy: string, tokens: string, type: string, id: string }>();
   const setPool = useSetRecoilState(poolState); 
-  const set: poolProps  = {
+  const set: Farm  = {
       name: name,
       wrapper: wrapper,
       spell: spell,
@@ -58,6 +47,7 @@ export const NewFarm: React.FC = () => {
       tokens: (tokens.split(',').map((x) => getToken(x)!)),
       rewards: [],
       type: getFarm(type)!,
+      id: id,
   }
   setPool(set);  
 

--- a/src/pages/Farm/newFarm/confirm.tsx
+++ b/src/pages/Farm/newFarm/confirm.tsx
@@ -104,9 +104,7 @@ export const Confirm: React.FC = () => {
             getAddress(Bank[network.chainId])
           ) as unknown as HomoraBank;
           let bytes: string
-          console.log(pool.type, "8888")
           if (pool.type === FarmType.SushiSwap) {
-            console.log('here')
             const spell = new kit.web3.eth.Contract(
               SUSHI_SPELL.abi as AbiItem[],
               getAddress(pool.spell)
@@ -125,7 +123,7 @@ export const Confirm: React.FC = () => {
                   0,
                   0,
                 ],
-                '3',
+                pool.id!,
               )
               .encodeABI();
           } else {

--- a/src/pages/Position/Add/add.tsx
+++ b/src/pages/Position/Add/add.tsx
@@ -2,11 +2,12 @@ import React from "react";
 import { atom, useSetRecoilState, useRecoilState } from 'recoil';
 import { getToken } from "src/utils/token";
 import { useParams } from "react-router-dom";
-import { poolState, poolProps } from "src/pages/Farm/newFarm/NewFarm";
+import { poolState } from "src/pages/Farm/newFarm/NewFarm";
 import { Supply } from "src/pages/Position/Add/supply";
 import { Borrow } from "src/pages/Position/Add/borrow";
 import { Confirm } from "src/pages/Position/Add/confirm";
 import { getFarm } from "src/utils/farm";
+import { Farm } from "src/config";
 
 
 export enum addPage {
@@ -38,10 +39,10 @@ export const addPositionState = atom({
 })
 
 export const Add: React.FC = () => {
-  const { positionId, collId, collateralSize, name, wrapper, spell, lp, apy, tokens, type } = useParams<{ positionId: string, collId: string, collateralSize: string, name: string, wrapper: string, spell: string, lp: string, apy: string, tokens: string, type: string}>();
+  const { positionId, collId, collateralSize, name, wrapper, spell, lp, apy, tokens, type, id } = useParams<{ positionId: string, collId: string, collateralSize: string, name: string, wrapper: string, spell: string, lp: string, apy: string, tokens: string, type: string, id: string}>();
   const setPool = useSetRecoilState(poolState); 
   const setPosition = useSetRecoilState(addPositionState); 
-  const set: poolProps = {
+  const set: Farm = {
       name: name,
       wrapper: wrapper,
       spell: spell,
@@ -50,6 +51,7 @@ export const Add: React.FC = () => {
       tokens: (tokens.split(',').map((x) => getToken(x)!)),
       rewards: [],
       type: getFarm(type)!,
+      id: id,
   }
   setPool(set);
   setPosition({

--- a/src/pages/Position/Add/confirm.tsx
+++ b/src/pages/Position/Add/confirm.tsx
@@ -121,7 +121,7 @@ export const Confirm: React.FC = () => {
                   0,
                   0,
                 ],
-                '3'
+                pool.id!
               )
               .encodeABI();
           } else {

--- a/src/pages/Position/Position.tsx
+++ b/src/pages/Position/Position.tsx
@@ -54,6 +54,7 @@ export const Position = () => {
           for (let farm of FARMS) {
             if (
               getAddress(underlying) === farm.lp &&
+              getAddress(positionInfo!.collToken) === farm.wrapper &&
               positionInfo!.collateralSize !== "0"
             ) {
               info.push({

--- a/src/pages/Position/PositionEntry.tsx
+++ b/src/pages/Position/PositionEntry.tsx
@@ -4,11 +4,10 @@ import BANK_ABI from "src/abis/dahlia_contracts/HomoraBank.json";
 import PROXYORACLE_ABI from "src/abis/dahlia_contracts/ProxyOracle.json";
 import { HomoraBank } from "src/generated/HomoraBank";
 import { ProxyOracle } from "src/generated/ProxyOracle";
-import { Bank, DEFAULT_GAS_PRICE } from "src/config";
+import { Bank, DEFAULT_GAS_PRICE, Farm, FarmType } from "src/config";
 import React from "react";
 import { getAddress } from "ethers/lib/utils";
 import { FarmInfo } from "src/components/FarmInfo";
-import { poolProps } from "src/pages/Farm/newFarm/NewFarm";
 import SUSHI_SPELL from "src/abis/dahlia_contracts/SushiswapSpellV1.json";
 import { SushiswapSpellV1 } from "src/generated/SushiswapSpellV1";
 import UBE_SPELL from "src/abis/dahlia_contracts/UbeswapMSRSpellV1.json";
@@ -24,10 +23,9 @@ import { humanFriendlyNumber } from "src/utils/number";
 import { CErc20Immutable } from "src/generated/CErc20Immutable";
 import CERC20_ABI from "src/abis/fountain_of_youth/CErc20Immutable.json";
 import { useAPR } from "../../hooks/useAPR"
-import { FarmType } from "src/config"
 
 interface Props {
-  pool: poolProps;
+  pool: Farm;
   positionId: number;
   collateralSize: string;
   collId: string;
@@ -40,10 +38,11 @@ export const PositionEntry: React.FC<Props> = (props: Props) => {
   const history = useHistory();
   const scale = toBN(2).pow(toBN(112));
 
-  const [apr, refetchapr] = useAPR(
+  const [apr] = useAPR(
     props.pool.lp,
     props.pool.wrapper,
     props.pool.type,
+    props.pool.id
   );
 
   const bank = React.useMemo(
@@ -217,7 +216,6 @@ export const PositionEntry: React.FC<Props> = (props: Props) => {
             onClick={async () => {
               const kit = await getConnectedKit();
               try {
-                console.log(props.positionId, 'this here')
                 setConfirmLoading(true);
                 const bank = new kit.web3.eth.Contract(
                   BANK_ABI.abi as AbiItem[],

--- a/src/pages/Position/Remove/remove.tsx
+++ b/src/pages/Position/Remove/remove.tsx
@@ -2,13 +2,14 @@ import React from "react";
 import { atom, useSetRecoilState, useRecoilState } from 'recoil';
 import { getToken } from "src/utils/token";
 import { useParams } from "react-router-dom";
-import { poolState, poolProps } from "src/pages/Farm/newFarm/NewFarm";
+import { poolState } from "src/pages/Farm/newFarm/NewFarm";
 import { emptyPositionState } from "../Add/add";
 import { RemoveTokens } from "./removeTokens";
 import { Payback } from "./payback";
 import { Confirm } from "./confirm";
 import { getFarm } from "src/utils/farm";
 import { Header } from "src/components/Header";
+import { Farm } from "src/config";
 
 export enum removePage {
     Remove, 
@@ -27,11 +28,11 @@ export const removePositionState = atom({
 })
 
 export const Remove: React.FC = () => {
-  const { positionId, collId, collateralSize, name, wrapper, spell, lp, apy, tokens, type } = useParams<{ positionId: string, collId: string, collateralSize: string, name: string, wrapper: string, spell: string, lp: string, apy: string, tokens: string, type: string}>();
+  const { positionId, collId, collateralSize, name, wrapper, spell, lp, apy, tokens, type, id } = useParams<{ positionId: string, collId: string, collateralSize: string, name: string, wrapper: string, spell: string, lp: string, apy: string, tokens: string, type: string, id: string}>();
   const setPool = useSetRecoilState(poolState); 
   const setPosition = useSetRecoilState(removePositionState); 
 
-  const set: poolProps  = {
+  const set: Farm  = {
       name: name,
       wrapper: wrapper,
       spell: spell,
@@ -40,6 +41,7 @@ export const Remove: React.FC = () => {
       tokens: (tokens.split(',').map((x) => getToken(x)!)),
       rewards: [],
       type: getFarm(type)!,
+      id: id,
   }
   setPool(set); 
   setPosition({


### PR DESCRIPTION
Integrate with the redeployed Sushiswap minichef contracts after the Optics migration. Two new pools include cusd<>ceur and mobi<>celo. Had to account for the id of each sushiswap pool.